### PR TITLE
Show all secret phrase candidates instead of showing the keyword selector

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,21 +1,18 @@
 import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { KEYWORDS } from './constants';
 import { App } from './App.tsx';
 
 describe('App', () => {
   describe('calculation', () => {
     it.each`
-      numbers              | operators     | keyword           | answer
-      ${[undefined, 0, 0]} | ${['+', '+']} | ${'インボリック'} | ${''}
-      ${[0, undefined, 0]} | ${['+', '+']} | ${'インボリック'} | ${''}
-      ${[0, 0, undefined]} | ${['+', '+']} | ${'インボリック'} | ${''}
-      ${[0, 1, 2]}         | ${['+', '+']} | ${'サーオィン'}   | ${'3サーオィン'}
-      ${[0, 1, 2]}         | ${['*', '-']} | ${'バス'}         | ${'-2バス'}
-      ${[0, 1, 2]}         | ${['+', '*']} | ${'ベルテン'}     | ${'2ベルテン'}
-      ${[0, 1, 2]}         | ${['-', '*']} | ${'ルーナサ'}     | ${'-2ルーナサ'}
+      numbers              | operators
+      ${[undefined, 0, 0]} | ${['+', '+']}
+      ${[0, undefined, 0]} | ${['+', '+']}
+      ${[0, 0, undefined]} | ${['+', '+']}
     `(
-      '`$numbers.0 $operators.0 $numbers.1 $operators.1 $numbers.2` and $keyword should be `$answer`',
-      async ({ numbers, operators, keyword, answer }) => {
+      'when a expr is `$numbers.0 $operators.0 $numbers.1 $operators.1 $numbers.2`, phrase candidates should be empty',
+      async ({ numbers, operators }) => {
         const user = userEvent.setup();
         render(<App />);
 
@@ -36,16 +33,52 @@ describe('App', () => {
           );
         }
 
-        await user.click(
-          within(screen.getByRole('radiogroup', { name: 'Keyword' })).getByRole(
-            'radio',
-            { name: keyword },
-          ),
-        );
+        for (const keyword of KEYWORDS) {
+          expect(
+            screen.getByRole('textbox', {
+              name: `phrase-candidate-${keyword}`,
+            }),
+          ).toHaveValue('');
+        }
+      },
+    );
 
-        expect(screen.getByRole('textbox', { name: 'answer' })).toHaveValue(
-          answer,
-        );
+    it.each`
+      numbers      | operators     | calcResult
+      ${[0, 1, 2]} | ${['+', '+']} | ${'3'}
+      ${[0, 1, 2]} | ${['*', '-']} | ${'-2'}
+      ${[0, 1, 2]} | ${['+', '*']} | ${'2'}
+      ${[0, 1, 2]} | ${['-', '*']} | ${'-2'}
+    `(
+      'when a expr is `$numbers.0 $operators.0 $numbers.1 $operators.1 $numbers.2`, phrase candidates should be has `$calcResult` as a prefix',
+      async ({ numbers, operators, calcResult }) => {
+        const user = userEvent.setup();
+        render(<App />);
+
+        for (const [i, num] of numbers.entries()) {
+          const input = screen.getByRole('textbox', { name: `Num ${i + 1}` });
+          if (num === undefined) {
+            await user.clear(input);
+            continue;
+          }
+          await user.type(input, `${num}`);
+        }
+
+        for (const [i, op] of operators.entries()) {
+          await user.click(
+            within(
+              screen.getByRole('radiogroup', { name: `Op ${i + 1}` }),
+            ).getByRole('radio', { name: op }),
+          );
+        }
+
+        for (const keyword of KEYWORDS) {
+          expect(
+            screen.getByRole('textbox', {
+              name: `phrase-candidate-${keyword}`,
+            }),
+          ).toHaveValue(`${calcResult}${keyword}`);
+        }
       },
     );
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,24 +7,9 @@ import {
   View,
   defaultTheme,
 } from '@adobe/react-spectrum';
-import {
-  KeywordSelector,
-  NumberInput,
-  Operator,
-  OperatorInput,
-  AppFooter,
-} from './components';
+import { KEYWORDS } from './constants';
+import { NumberInput, Operator, OperatorInput, AppFooter } from './components';
 import { CopyableOutput } from './components/forms/CopyableOutput';
-
-const KEYWORDS = [
-  'インボリック',
-  'サーオィン',
-  'バス',
-  'ベルテン',
-  'ルーナサ',
-] as const;
-
-type Keyword = (typeof KEYWORDS)[number];
 
 function isNumberArray(
   maybeNumber: (number | undefined)[],
@@ -59,9 +44,8 @@ export function App() {
     [number | undefined, number | undefined, number | undefined]
   >([undefined, undefined, undefined]);
   const [operators, setOperators] = useState<[Operator, Operator]>(['+', '+']);
-  const [keyword, setKeyword] = useState<Keyword>('インボリック');
 
-  const answer = useMemo(() => {
+  const calculationResult = useMemo(() => {
     let calculatedResult: number | undefined;
     if (['*'].includes(operators[1])) {
       calculatedResult = applyOperator(operators[0], [
@@ -75,12 +59,8 @@ export function App() {
       ]);
     }
 
-    if (calculatedResult === undefined) {
-      return undefined;
-    }
-
-    return `${calculatedResult}${keyword}`;
-  }, [numbers, keyword, operators]);
+    return calculatedResult;
+  }, [numbers, operators]);
 
   return (
     <Provider
@@ -199,24 +179,26 @@ export function App() {
                 </View>
               </Flex>
 
-              <KeywordSelector
-                label="Keyword"
-                value={keyword}
-                onSelectionChange={setKeyword}
-                keywords={KEYWORDS}
-              />
-
               <View>
-                <Heading level={2}>解答</Heading>
-                <CopyableOutput
-                  value={answer}
-                  inputMaxWidth={'size-3000'}
-                  isTextHidden={{
-                    base: true,
-                    L: false,
-                  }}
-                  ariaLabel="answer"
-                />
+                <Heading level={2}>フレーズ候補</Heading>
+                <Flex direction="column" gap="size-100">
+                  {KEYWORDS.map((keyword) => (
+                    <CopyableOutput
+                      key={keyword}
+                      value={
+                        calculationResult
+                          ? `${calculationResult}${keyword}`
+                          : undefined
+                      }
+                      inputMaxWidth={'size-3000'}
+                      isTextHidden={{
+                        base: true,
+                        L: false,
+                      }}
+                      ariaLabel={`phrase-candidate-${keyword}`}
+                    />
+                  ))}
+                </Flex>
               </View>
             </Flex>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,13 @@ import {
   defaultTheme,
 } from '@adobe/react-spectrum';
 import { KEYWORDS } from './constants';
-import { NumberInput, Operator, OperatorInput, AppFooter } from './components';
-import { CopyableOutput } from './components/forms/CopyableOutput';
+import {
+  AppFooter,
+  CopyableOutput,
+  NumberInput,
+  Operator,
+  OperatorInput,
+} from './components';
 
 function isNumberArray(
   maybeNumber: (number | undefined)[],

--- a/src/components/buttons/ClipboardCopyButton/index.tsx
+++ b/src/components/buttons/ClipboardCopyButton/index.tsx
@@ -18,7 +18,7 @@ export function ClipboardCopyButton({
   return (
     <Button
       onPress={onPress}
-      variant="primary"
+      variant="secondary"
       isDisabled={isDisabled}
       aria-label="copy"
     >

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,7 @@
+export const KEYWORDS = [
+  'インボリック',
+  'サーオィン',
+  'バス',
+  'ベルテン',
+  'ルーナサ',
+] as const;


### PR DESCRIPTION
- **feat: use the secondary variant for the phrase copy button because multiple copy buttons are displayed and are too prominent**
- **feat: show all secret phrase candidates instead of showing the keyword selector to quickly copy candidates**
- **refactor: merge import declaration for simplicity**